### PR TITLE
fix deprecation warning about getOwner

### DIFF
--- a/app/transforms/file.js
+++ b/app/transforms/file.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 import config from '../config/environment';
 
 const { isEmpty, copy, assign } = Ember;
@@ -31,7 +30,7 @@ export default Transform.extend({
    * @public
    */
   deserialize: function(serialized, attributeMeta) {
-    const File = getOwner(this)._lookupFactory('object:file');
+    const File = Ember.getOwner(this)._lookupFactory('object:file');
 
     return File.create(serialized, config.paperclip, assign(copy(attributeMeta), {
       isNew: isEmpty(serialized),

--- a/app/transforms/file.js
+++ b/app/transforms/file.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import config from '../config/environment';
 
-const { isEmpty, copy, assign } = Ember;
+const { isEmpty, copy, assign, getOwner } = Ember;
 const { Transform } = DS;
 
 /**
@@ -30,7 +30,7 @@ export default Transform.extend({
    * @public
    */
   deserialize: function(serialized, attributeMeta) {
-    const File = Ember.getOwner(this)._lookupFactory('object:file');
+    const File = getOwner(this)._lookupFactory('object:file');
 
     return File.create(serialized, config.paperclip, assign(copy(attributeMeta), {
       isNew: isEmpty(serialized),


### PR DESCRIPTION
Fixes this deprecation warning:
```
DEPRECATION: ember-getowner-polyfill is now a true polyfill. Use
Ember.getOwner directly instead of importing from
ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```